### PR TITLE
Move the gatsby-node-helpers package into dependencies to make it available for builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-source-greenhouse",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Gatsby source plugin for loading job posts from greenhouse.io",
   "main": "gatsby-node.js",
   "scripts": {
@@ -29,12 +29,12 @@
   "author": "Diego La Manno <diegolamanno@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.16.2"
+    "axios": "^0.16.2",
+    "gatsby-node-helpers": "^0.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.6.0",
-    "gatsby-node-helpers": "^0.3.0"
+    "babel-preset-env": "^1.6.0"
   }
 }


### PR DESCRIPTION
Gah, so sorry about this @diegolamanno !  Was running with `2.0.1` from NPM and got this error on `gatsby develop`:

```
success load plugins — 0.181 s
error Plugin gatsby-source-greenhouse returned an error


  Error: Cannot find module 'gatsby-node-helpers'
```

I believe it's because I had mistakenly put the node creation helper into a devDependency.