### PR TITLE
Get Multiple Job Posts Per Job

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -99,14 +99,20 @@ exports.sourceNodes = async ({ boundActionCreators }, { apiToken, pluginOptions 
       }
 
       var jobPostsMapping = jobPosts.reduce((map, jobPost) => { 
-        map[jobPost.job_id] = jobPost
+        if(map[jobPost.job_id]){
+          map[jobPost.job_id].push(jobPost)
+        } else {
+          map[jobPost.job_id] = [jobPost]
+        }
+
         return map
       }, {})
+
 
       var jobPostsForDepartment = jobs.reduce((arr, job) => {
         const mappedJobPost = jobPostsMapping[job.id]
         if (mappedJobPost) {
-          arr.push(mappedJobPost)
+          arr.push(...mappedJobPost)
         }
         return arr
       }, [])

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,5 +1,5 @@
-const crypto = require('crypto')
 const axios = require('axios')
+
 import { JobPostNode, DepartmentNode } from './nodes'
 
 /**
@@ -54,9 +54,9 @@ async function getDepartments(apiToken) {
  * @param obj object.
  * @returns object.
  */
-const changeId = obj => {
+const changeId = (obj, property = "id") => {
 	const updatedObj = obj
-	updatedObj.id = updatedObj.id.toString()
+	updatedObj[property] = updatedObj[property].toString()
 	return updatedObj
 }
 
@@ -64,6 +64,53 @@ const defaultPluginOptions = {
   jobPosts: {
     live: true
   }
+}
+
+/**
+ * Return all open jobs for a given department
+ * @param jobs array of jobs or empty array.
+ * @param jobPosts array of jobPosts.
+ * @returns array of jobs with new jobPosts property.
+ */
+function mapJobPostsToJobs(jobs, jobPosts) {
+  if (!jobs.length) {
+    return jobs
+  }
+
+  const jobsMap = {}
+
+  jobs.forEach((job) => (jobsMap[job.id] = { ...job, jobPosts: [] }))
+
+  jobPosts.forEach((jobPost) => {
+    if (jobsMap[jobPost.job_id] !== undefined) {
+      jobsMap[jobPost.job_id].jobPosts.push(jobPost)
+    }
+  })
+
+  return Object.values(jobsMap)
+}
+
+/**
+ * Return all open jobs for a given department
+ * @param jobs array of jobs or empty array.
+ * @param jobPosts array of jobPosts or an empty array.
+ * @returns array of all of the jobPosts found on the jobs.
+ */
+function flattenJobPosts(jobs, jobPosts) {
+  if (!jobs.length) {
+    return jobs
+  }
+
+  const jobIdsMap = {}
+  jobs.forEach((job) => (jobIdsMap[job.id] = true))
+
+  const flattenedJobPosts = jobPosts.map((jobPost) => {
+    if (jobIdsMap[jobPost.job_id]) {
+      return jobPost
+    }
+  })
+
+  return flattenedJobPosts.filter((jobPost) => jobPost !== undefined)
 }
 
 exports.sourceNodes = async ({ boundActionCreators }, { apiToken, pluginOptions }) => {
@@ -78,10 +125,16 @@ exports.sourceNodes = async ({ boundActionCreators }, { apiToken, pluginOptions 
   try {
     departments = await getDepartments(apiToken).then(response => response.data)
     jobPosts = await getJobPosts(apiToken, options.jobPosts).then(response => response.data)
+    
   } catch (e) {
     console.log(`Failed to fetch data from Greenhouse`)
     process.exit(1)
   }
+
+  const convertedJobPosts = jobPosts.map((jobPost) => {
+      const convertedJobPost = changeId(jobPost)
+      return changeId(convertedJobPost, "job_id")
+  })
 
   console.log(`jobPosts fetched`, jobPosts.length)
   console.log(`departments fetched`, departments.length)
@@ -93,36 +146,17 @@ exports.sourceNodes = async ({ boundActionCreators }, { apiToken, pluginOptions 
       try {
         const jobsForDepartmentResults = await getJobsForDepartment(apiToken, convertedDepartment.id)
         jobs = jobsForDepartmentResults.data.map(job => changeId(job))
+        jobs = mapJobPostsToJobs(jobs, convertedJobPosts)
       } catch (e) {
         console.log(`Failed to fetch jobs for department.`)
         process.exit(1)
       }
 
-      var jobPostsMapping = jobPosts.reduce((map, jobPost) => { 
-        if(map[jobPost.job_id]){
-          map[jobPost.job_id].push(jobPost)
-        } else {
-          map[jobPost.job_id] = [jobPost]
-        }
-
-        return map
-      }, {})
-
-
-      var jobPostsForDepartment = jobs.reduce((arr, job) => {
-        const mappedJobPost = jobPostsMapping[job.id]
-        if (mappedJobPost) {
-          arr.push(...mappedJobPost)
-        }
-        return arr
-      }, [])
-
-      convertedDepartment.jobPosts =  jobPostsForDepartment
+      convertedDepartment.jobPosts =  flattenJobPosts(jobs, convertedJobPosts)
       const departmentNode = DepartmentNode(changeId(convertedDepartment))
 
-      jobPostsForDepartment.forEach(jobPost => {
-        const convertedJobPost = changeId(jobPost)
-        const jobPostNode = JobPostNode(convertedJobPost, { 
+      convertedDepartment.jobPosts.forEach(jobPost => {
+        const jobPostNode = JobPostNode(jobPost, { 
           parent: departmentNode.id 
         })
         createNode(jobPostNode)

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -3,7 +3,6 @@ import createNodeHelpers from 'gatsby-node-helpers'
 const {
   createNodeFactory,
   generateNodeId,
-  generateTypeName,
 } = createNodeHelpers({
   typePrefix: `Greenhouse`,
 })


### PR DESCRIPTION
Greenhouse made an update to allow users to have multiple job posts per job. The old code for this plugin overwrote job posts while mapping to jobs allowing only one job post per job. This refactor gets rid of some unused imports and appends multiple job posts to each job and all the job posts for all of the jobs to the department.